### PR TITLE
[#154103976] Make Integrations Report to be accessed only by URL

### DIFF
--- a/app/views/layouts/dbhero/application.html.slim
+++ b/app/views/layouts/dbhero/application.html.slim
@@ -21,7 +21,6 @@ html.grey.lighten-3
         li= link_to('Clients', '/', style: "font-size: 14px; color: #777;")
         li= link_to('Admin', '/admin/base_admin', style: "font-size: 14px; color: #777;")
         li= link_to('G5 Ops', '/g5_ops/status.html', target: "_blank", style: "font-size: 14px; color: #777;")
-        li= link_to('Integrations Report', root_path, target: "_blank", style: "font-size: 14px; color: #555; background-color: #e7e7e7;")
       ul.right-align
         = link_to("Logout", 'g5_auth/users/sign_out', style: "font-size: 14px; color: #777;")
 

--- a/lib/dbhero/version.rb
+++ b/lib/dbhero/version.rb
@@ -1,3 +1,3 @@
 module Dbhero
-  VERSION = "1.1.13"
+  VERSION = "1.1.14"
 end


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
* Make Integrations Report to be accessed only by URL
* Remove Integrations Reports on navbar

### Important Links (Pivotal, Additional Repositories, etc):
* Pivotal Story [#154103976](https://www.pivotaltracker.com/story/show/154103976)

### Additional Information (Optional)
* https://github.com/g5search/g5-integrations-dashboard/pull/1226